### PR TITLE
Handle edge case for empty meshfilters

### DIFF
--- a/Runtime/DecalMesh.cs
+++ b/Runtime/DecalMesh.cs
@@ -394,6 +394,9 @@ namespace SamDriver.Decal
                 {
                     // only interested in meshes on static objects
                     if (!meshFilter.gameObject.isStatic) continue;
+                    
+                    // also handle edge case where empty meshfilters exist in the scene
+                    if (meshFilter.sharedMesh == null) continue;
 
                     // don't project against other decals
                     #if UNITY_2019_2_OR_NEWER


### PR DESCRIPTION
Having empty meshfilters in the scene causes the system to fail. Resulting in an error:

```
NullReferenceException: Object reference not set to an instance of an object
SamDriver.Decal.DecalMesh+<WorldMeshFilters>d__55.MoveNext () (at Packages/com.samdriver.driven-decals/Runtime/DecalMesh.cs:408)
SamDriver.Decal.MeshProjection.ScheduleTrimJobs (System.Collections.Generic.List`1[SamDriver.Decal.RawMesh]& rawMeshes, System.Collections.Generic.List`1[Unity.Collections.NativeArray`1[SamDriver.Decal.Triangle]]& allResultingTriangles, System.Collections.Generic.List`1[Unity.Jobs.JobHandle]& trimJobHandles, UnityEngine.Transform decalTransform, System.Collections.Generic.IEnumerable`1[T] meshFilters, System.Boolean shouldUsePersistentAllocation, System.Boolean immediatelyStart) (at Packages/com.samdriver.driven-decals/Runtime/MeshProjection.cs:164)
SamDriver.Decal.MeshProjection.GenerateProjectedDecalMesh (System.Collections.Generic.IEnumerable`1[T] meshFilters, UnityEngine.Transform decalTransform) (at Packages/com.samdriver.driven-decals/Runtime/MeshProjection.cs:269)
SamDriver.Decal.DecalMesh.GenerateProjectedMeshImmediate () (at Packages/com.samdriver.driven-decals/Runtime/DecalMesh.cs:313)
SamDriver.Decal.DecalMeshInspector.ProjectMeshButtonGUI (SamDriver.Decal.DecalMesh primaryItem, SamDriver.Decal.DecalMesh[] items, System.Boolean isEditingMultipleObjects) (at Packages/com.samdriver.driven-decals/Editor/DecalMeshInspector.cs:89)
SamDriver.Decal.DecalMeshInspector.OnInspectorGUI () (at Packages/com.samdriver.driven-decals/Editor/DecalMeshInspector.cs:42)
UnityEditor.UIElements.InspectorElement+<>c__DisplayClass59_0.<CreateIMGUIInspectorFromEditor>b__0 () (at <60f4a7b331a5480aaa94dbc2506830d5>:0)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr, Boolean&)
```

Adding this check prevents this edge case from breaking DecalMesh.